### PR TITLE
Fix: Made the navbar position to fixed on top

### DIFF
--- a/src/public/css/navbar.css
+++ b/src/public/css/navbar.css
@@ -11,7 +11,10 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-
+  position: fixed;
+  z-index: 99;
+  left: 50%;
+  transform: translate(-50%, 0);
   --padding-container: 0;
 }
 
@@ -157,5 +160,5 @@
   z-index: 200;
   border-top-right-radius: 25px;
   border-bottom-right-radius: 25px;
-  box-shadow: 0 0 6px 12x rgba(0,0,0,0.075);
+  box-shadow: 0 0 6px 12x rgba(0, 0, 0, 0.075);
 }


### PR DESCRIPTION
Fix : #67 

Added the Below css in `.nav` class

```
 position: fixed; // Fix the nav on the top
 z-index: 99; // to display it over the content
// below 2 lines are used to make the nav center align
 left: 50%; 
 transform: translate(-50%, 0);
```
![FAQSection](https://github.com/yamilt351/scraper/assets/107350270/f98500a0-852c-404a-aa2b-184506ee37ce)
![DownloadYourResultsSection](https://github.com/yamilt351/scraper/assets/107350270/ec6134d7-2498-4819-b0d7-926cb2369555)
![featureSection](https://github.com/yamilt351/scraper/assets/107350270/0810d0d5-c35c-4f77-8ac5-49ae090668b8)
![page1](https://github.com/yamilt351/scraper/assets/107350270/e449d752-8f43-4e39-a6c1-11c026cd3269)

